### PR TITLE
Return error in either case

### DIFF
--- a/parsers/timetableparser.go
+++ b/parsers/timetableparser.go
@@ -11,16 +11,10 @@ type TimetableParser interface {
 
 func (t *Timetable) ParseV1(s string) error {
 	err := json.Unmarshal([]byte(s), &t)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func (t *Timetable) ComposeV1() (string, error) {
 	res, err := json.Marshal(t)
-	if err != nil {
-		return string(res), err
-	}
-	return string(res), nil
+	return string(res), err
 }


### PR DESCRIPTION
That was just additional unnecessary boilerplate. Error can be either "nil" or "Error", so you don't need to check if error is not "nil"